### PR TITLE
Add an empty [tool.setuptools_scm] section to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+
 [tool.cibuildwheel]
 test-requires = "pytest"
 test-command = "pytest {project}/tests"


### PR DESCRIPTION
Fixes #29.

See https://setuptools-scm.readthedocs.io/en/latest/usage/. This section is expected to be present, but it may be empty if no non-default settings are required.

This addition does not change the contents of the binary wheels.