### PR TITLE
Do not distribute Cython-generated C++ sources in binary wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup_args = dict(
     package_dir={"": "src"},
     packages=find_packages("src"),
     include_package_data=True,
+    exclude_package_data={"": ["*.cpp"]},
     ext_modules=extensions,
     setup_requires=["setuptools_scm"] + wheel,
     python_requires=">=3.8",


### PR DESCRIPTION
I would argue that including the Cython-generated `.cpp` C++ sources in the binary wheels is not likely to be useful to end users, and dropping them greatly decreases the size of the binary wheels. In my testing, the `.whl` file goes from 440K to 176K, and the uncompressed installation goes from 2.3M to 528K.

The `.pyx` and `.pxd` files aren’t strictly necessary either, but they are much smaller, and they do help provide better tracebacks. There’s a discussion of this topic in https://github.com/aio-libs/aiohttp/issues/6399, where I proposed a similar change in aiohttp.

This change does not affect the contents of the sdist.