### PR TITLE
Remove unused pytest-cython test dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ deps =
     cython >= 0.28.5
     pytest
     pytest-randomly
-    pytest-cython
     cov: coverage
 changedir= {toxinidir}
 setenv =


### PR DESCRIPTION
According to https://pypi.org/project/pytest-cython/, this plugin allows one to run doctests from `.pyx` files, but:

- I don’t see any doctests in the `.pyx` files
- The pytest option `--doctest-cython` doesn’t appear anywhere in the source
- Removing the dependency doesn’t change the number of tests that are run