### PR TITLE
Drop build_aarch64_wheels job in favor of ubuntu-24.04-arm os

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,9 +18,16 @@ jobs:
         # macos-13 runners are still x86_64, macos-14 (latest) are arm64; we want to build
         # the x86_64 wheel on/for x86_64 macs
         os: [ "ubuntu-latest", "windows-latest", "macos-13" ]
+        arch: [auto64]
+        include:
+          - os: macos-latest
+            arch: universal2
+          - os: windows-latest
+            arch: auto32
+          - os: ubuntu-24.04-arm
+            arch: aarch64
     env:
-      CIBW_ARCHS: auto64
-      CIBW_ARCHS_MACOS: "x86_64 universal2"
+      CIBW_ARCHS: ${{ matrix.arch }}
       # Skip
       #
       # * Python 3.6 and 3.7 on all platforms,
@@ -43,42 +50,11 @@ jobs:
           name: wheels-${{ matrix.os }}
           path: dist/*.whl
 
-  build_aarch64_wheels:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # aarch64 uses qemu so it's slow, build each py version in parallel jobs
-        python: [38, 39, 310, 311, 312, 313]
-        arch: [aarch64]
-    env:
-      # Skip building aarch64 wheels for musllinux until someone ask...
-      CIBW_SKIP: "*-musllinux*"
-      CIBW_BUILD: cp${{ matrix.python }}-*
-      CIBW_ARCHS: ${{ matrix.arch }}
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - uses: docker/setup-qemu-action@v3.3.0
-      with:
-        # temporarily pin to qemu@v8 to workaround non-determininstic gcc segfaults
-        # https://github.com/docker/setup-qemu-action/issues/188
-        image: tonistiigi/binfmt:qemu-v8.1.5
-        platforms: all
-    - name: Install dependencies
-      run: pip install cibuildwheel
-    - name: Build and Test Wheels
-      run: python -m cibuildwheel --output-dir dist
-    - uses: actions/upload-artifact@v4
-      with:
-        name: wheels-${{ matrix.python }}-linux-${{ matrix.arch }}
-        path: dist/*.whl
-
   deploy:
     # only run if the commit is tagged...
     if: startsWith(github.ref, 'refs/tags/v')
     # ... and all build jobs completed successfully
-    needs: [build_wheels, build_aarch64_wheels]
+    needs: [build_wheels]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Derived from https://github.com/fonttools/fonttools/commit/cdf5a6e69b8012887b43642ee6c21206895149f4

This would drop separate macOS x86_64 wheels, in favor of universal2-only. If this isn't desired, I can try to add x86_64 back in.