### PR TITLE
Fix build for Python 3.13

### DIFF
--- a/src/openstep_plist/writer.pyx
+++ b/src/openstep_plist/writer.pyx
@@ -197,7 +197,7 @@ cdef class Writer:
             return 1
         elif isinstance(obj, float):
             return self.write_short_float_repr(obj)
-        elif isinstance(obj, (int, long)):
+        elif isinstance(obj, int):
             return self.write_unquoted_string(unicode(obj))
         elif isinstance(obj, list):
             return self.write_array_from_list(obj)


### PR DESCRIPTION
I'm not sure what (dependency?) caused this, but I currently can't build openstep_plist on macOS with Python 3.13.5:

```
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
              elif isinstance(obj, bool):
                  self.dest.push_back(c'1' if obj else c'0')
                  return 1
              elif isinstance(obj, float):
                  return self.write_short_float_repr(obj)
              elif isinstance(obj, (int, long)):
                                         ^
      ------------------------------------------------------------
      
      src/openstep_plist/writer.pyx:200:35: undeclared name not builtin: long
```
I noticed while I tried to build for Free-threaded Python, which which we don't build wheels yet.

I'm assuming the 'long' thing is a remnant from Python 2.