### PR TITLE
Fix Cython 3.1 compatibility

### DIFF
--- a/src/openstep_plist/writer.pyx
+++ b/src/openstep_plist/writer.pyx
@@ -197,7 +197,7 @@ cdef class Writer:
             return 1
         elif isinstance(obj, float):
             return self.write_short_float_repr(obj)
-        elif isinstance(obj, (int, long)):
+        elif isinstance(obj, int):
             return self.write_unquoted_string(unicode(obj))
         elif isinstance(obj, list):
             return self.write_array_from_list(obj)


### PR DESCRIPTION
The `long` type was unified with `int` for Python 3, and support for Python 2 was removed for Cython 3.1,
https://github.com/cython/cython/issues/2800.

(You can reproduce failure to compile with Cython 3.1 by just checking out `master` and running `python3 -m build`.)