### PR TITLE
Modernize build system and add Windows ARM64 wheel support

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheel ${{ matrix.os }}
+    name: Build wheel ${{ matrix.os }} (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -24,6 +24,8 @@ jobs:
             arch: universal2
           - os: ubuntu-24.04-arm
             arch: aarch64
+          - os: windows-latest
+            arch: ARM64
     env:
       CIBW_ARCHS: ${{ matrix.arch }}
       # Skip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ requires = [
     "setuptools<72.2.0; platform_python_implementation == 'PyPy'",
     "setuptools; platform_python_implementation != 'PyPy'",
     "wheel",
+    "packaging",
+    "setuptools_scm",
     "cython >= 0.28.5",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,9 @@ from setuptools.command.sdist import sdist as _sdist
 from distutils import log
 import os
 import sys
-import pkg_resources
-from io import open
+from importlib.metadata import version as get_version, PackageNotFoundError
+from packaging.version import Version
 import re
-
-
-argv = sys.argv[1:]
-needs_wheel = {"bdist_wheel"}.intersection(argv)
-wheel = ["wheel"] if needs_wheel else []
 
 # check if minimum required Cython is available
 cython_version_re = re.compile(r'\s*"cython\s*>=\s*([0-9][0-9\w\.]*)\s*"')
@@ -23,13 +18,11 @@ with open("pyproject.toml", "r", encoding="utf-8") as fp:
             break
     else:
         sys.exit("error: could not parse cython version from pyproject.toml")
+required_cython = "cython >= %s" % cython_min_version
 try:
-    required_cython = "cython >= %s" % cython_min_version
-    pkg_resources.require(required_cython)
-except pkg_resources.ResolutionError:
+    with_cython = Version(get_version("cython")) >= Version(cython_min_version)
+except PackageNotFoundError:
     with_cython = False
-else:
-    with_cython = True
 
 
 class cython_build_ext(_build_ext):
@@ -91,19 +84,11 @@ class cython_sdist(_sdist):
         _sdist.run(self)
 
 
-# need to include this for Visual Studio 2008 doesn't have stdint.h
-include_dirs = (
-    [os.path.join(os.path.dirname(__file__), "vendor", "msinttypes")]
-    if os.name == "nt" and sys.version_info < (3,)
-    else []
-)
-
 cython_modules = ["parser", "util", "writer", "_test"]
 extensions = [
     Extension(
         "openstep_plist." + mod,
         sources=["src/openstep_plist/%s.pyx" % mod],
-        include_dirs=include_dirs,
         language="c++",
         extra_compile_args=["-std=c++11"] if sys.platform != "win32" else [],
     )
@@ -130,7 +115,6 @@ setup_args = dict(
     include_package_data=True,
     exclude_package_data={"": ["*.cpp"]},
     ext_modules=extensions,
-    setup_requires=["setuptools_scm"] + wheel,
     python_requires=">=3.8",
     cmdclass={"build_ext": cython_build_ext, "sdist": cython_sdist},
     zip_safe=False,

--- a/src/openstep_plist/util.pyx
+++ b/src/openstep_plist/util.pyx
@@ -1,16 +1,12 @@
 #cython: language_level=3
 #distutils: define_macros=CYTHON_TRACE_NOGIL=1
 
-from cpython.version cimport PY_MAJOR_VERSION
 from libc.stdint cimport uint16_t, uint32_t
-import sys
 
 
 cdef inline unicode tounicode(s, encoding="ascii", errors="strict"):
     if type(s) is unicode:
         return <unicode>s
-    elif PY_MAJOR_VERSION < 3 and isinstance(s, bytes):
-        return (<bytes>s).decode(encoding, errors=errors)
     elif isinstance(s, unicode):
         return unicode(s)
     else:
@@ -19,9 +15,9 @@ cdef inline unicode tounicode(s, encoding="ascii", errors="strict"):
 
 cdef inline object tostr(s, encoding="ascii", errors="strict"):
     if isinstance(s, bytes):
-        return s if PY_MAJOR_VERSION < 3 else s.decode(encoding, errors=errors)
+        return s.decode(encoding, errors=errors)
     elif isinstance(s, unicode):
-        return s.encode(encoding, errors=errors) if PY_MAJOR_VERSION < 3 else s
+        return s
     else:
         raise TypeError(f"Could not convert to str: {s!r}")
 


### PR DESCRIPTION
This PR modernizes the build system and adds Windows ARM64 support:

- **Replace `pkg_resources` with `importlib.metadata` and `packaging.version`** — `pkg_resources` was deprecated and removed from Python 3.14's stdlib, breaking builds on newer Python (see #28). The Cython version check now uses `importlib.metadata.version()` and `packaging.version.Version`.

- **Clean up deprecated/dead build configuration** — remove the deprecated `setup_requires` (superseded by `pyproject.toml` `[build-system].requires`), the associated argv-sniffing wheel logic, the no-op `from io import open`, and the dead VS2008 `msinttypes` `include_dirs` block (guarded by `sys.version_info < (3,)`). Add `packaging` and `setuptools_scm` as explicit build deps in `pyproject.toml`.

- **Remove dead Python 2 code from `util.pyx`** — drop `PY_MAJOR_VERSION < 3` branches in `tounicode()` and `tostr()`, along with the unused `cpython.version` cimport and `import sys`.

- **Add Windows ARM64 to CI wheel matrix** — add a `windows-latest` / `ARM64` entry so Windows ARM64 wheels are built and published to PyPI.